### PR TITLE
Improvements in the package

### DIFF
--- a/lib/rules/bof-newline.js
+++ b/lib/rules/bof-newline.js
@@ -1,12 +1,6 @@
 "use strict";
 
 //------------------------------------------------------------------------------
-// Requirements
-//------------------------------------------------------------------------------
-
-const lodash = require("lodash");
-
-//------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
 
@@ -39,13 +33,13 @@ module.exports = {
                 const sourceCode = context.getSourceCode(),
                     src = sourceCode.getText(),
                     location = {
-                        column: lodash.first(sourceCode.lines).length,
+                        column: 0,
                         line: 1
                     },
                     LF = "\n",
                     CRLF = `\r${LF}`,
-                    startsWithLF = lodash.startsWith(src, LF),
-                    startsWithCRLF = lodash.startsWith(src, CRLF);
+                    startsWithLF = src.startsWith(LF),
+                    startsWithCRLF = src.startsWith(CRLF);
                 /*
                  * Empty source is always valid: No content in file so we don't
                  * need to lint for a newline on the first line of content.

--- a/package.json
+++ b/package.json
@@ -2,13 +2,18 @@
   "name": "eslint-plugin-bof-newline",
   "description": "ESLint plugin to ensure that files begin with new line",
   "version": "1.0.1",
-  "main": "index.js",
+  "files": [
+    "/index.js",
+    "/lib"
+  ],
   "repository": "https://github.com/lucastaliberti/eslint-plugin-bof-newline.git",
   "author": "Lucas Taliberti de Sousa <lucastaliberti@gmail.com>",
   "license": "MIT",
   "keywords": [
     "eslint",
-    "eslintplugin"
+    "eslint-plugin",
+    "newline",
+    "eol-first"
   ],
   "scripts": {
     "test": "yarn run lint && yarn run unit",
@@ -21,8 +26,5 @@
   },
   "peerDependencies": {
     "eslint": ">=0.18.0"
-  },
-  "dependencies": {
-    "lodash": "^4.17.5"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2219,7 +2219,7 @@ lodash.sortby@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
 
-lodash@^4.13.1, lodash@^4.14.0, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.3.0:
+lodash@^4.13.1, lodash@^4.14.0, lodash@^4.17.4, lodash@^4.3.0:
   version "4.17.5"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.5.tgz#99a92d65c0272debe8c96b6057bc8fbfa3bed511"
 


### PR DESCRIPTION
Hey, I've found some details that I think are worth fixing, so that the package is smaller and easier to find. My changes:

* Removed `lodash` from the dependencies, as it was not really needed.

  By the way, fixed `location.column` value to indicate the beginning of file, not the end of the first line.

* Added `files` property to `package.json`, so that only the necessary files are packaged.

  As can be seen here: https://unpkg.com/browse/eslint-plugin-bof-newline@1.0.1/, currently the large `yarn.lock` is in the package. It seems that new versions of npm ignore it by default, but nonetheless, it's always safer to list exactly which files should be uploaded. Some other files, like `LICENSE`, `README.md`, and `package.json`, will still be uploaded automatically.

* Extended the list of keywords in `package.json`. It took me some time to find this plugin, as I expected it to be named something like `eol-first`, for symmetry with `eol-last` :-)